### PR TITLE
fix type in declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,7 @@ declare module 'scroll-hint' {
   }
 
   export default class ScrollHint {
-    constructor(selector: string | HTMLElement, option?:ScrollHintOption);
+    constructor(selector: string | NodeListOf<HTMLElement>, option?:ScrollHintOption);
     updateItems(): void;
   }
 }


### PR DESCRIPTION
Although the selector argument of the ScrollHint class constructor accepts the `HTMLElement` type, I think that this is a mistake in the `NodeListOf<HTMLElement>` type.