### PR TITLE
change offset to optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,30 +1,29 @@
 declare module 'scroll-hint' {
-
   interface i18n {
-    scrollable: string
+    scrollable: string;
   }
-  
+
   interface ScrollHintOption {
-    suggestClass?: string,
-    scrollableClass?: string,
-    scrollableRightClass?: string,
-    scrollableLeftClass?: string,
-    scrollHintClass?: string,
-    scrollHintIconClass?: string,
-    scrollHintIconAppendClass?: string,
-    scrollHintIconWrapClass?: string,
-    scrollHintText?: string,
-    scrollHintBorderWidth?: number,
-    remainingTime?: string,
-    enableOverflowScrolling?: boolean,
-    applyToParents?: boolean,
-    suggestiveShadow?: boolean,
-    offset: number,
-    i18n?: i18n
+    suggestClass?: string;
+    scrollableClass?: string;
+    scrollableRightClass?: string;
+    scrollableLeftClass?: string;
+    scrollHintClass?: string;
+    scrollHintIconClass?: string;
+    scrollHintIconAppendClass?: string;
+    scrollHintIconWrapClass?: string;
+    scrollHintText?: string;
+    scrollHintBorderWidth?: number;
+    remainingTime?: string;
+    enableOverflowScrolling?: boolean;
+    applyToParents?: boolean;
+    suggestiveShadow?: boolean;
+    offset?: number;
+    i18n?: i18n;
   }
 
   export default class ScrollHint {
-    constructor(selector: string | NodeListOf<HTMLElement>, option?:ScrollHintOption);
+    constructor(selector: string | NodeListOf<HTMLElement>, option?: ScrollHintOption);
     updateItems(): void;
   }
 }


### PR DESCRIPTION
<img width="310" alt="スクリーンショット 2021-04-23 20 59 01" src="https://user-images.githubusercontent.com/916624/115868771-ea115500-a477-11eb-8b9c-122bc4a87916.png">

If there is no offset in Typescript, a warning will be displayed, so how about changing offset to an option?