### PR TITLE
enhance: 単一のHTMLElementを受け付けるように

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,7 @@ declare module 'scroll-hint' {
   }
 
   export default class ScrollHint {
-    constructor(selector: string | NodeListOf<HTMLElement> | HTMLElement[], option?:ScrollHintOption);
+    constructor(selector: string | HTMLElement | NodeListOf<HTMLElement> | HTMLElement[], option?:ScrollHintOption);
     updateItems(): void;
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,7 @@ declare module 'scroll-hint' {
   }
 
   export default class ScrollHint {
-    constructor(selector: string | NodeListOf<HTMLElement>, option?:ScrollHintOption);
+    constructor(selector: string | NodeListOf<HTMLElement> | HTMLElement[], option?:ScrollHintOption);
     updateItems(): void;
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,14 @@ export default class ScrollHint {
   constructor(ele, option) {
     this.opt = assign({}, defaults, option);
     this.items = [];
-    const elements = typeof ele === 'string' ? document.querySelectorAll(ele) : ele;
+    let elements;
+    if (ele instanceof HTMLElement) {
+      elements = [ele];
+    } else if (typeof ele === 'string') {
+      elements = document.querySelectorAll(ele);
+    } else {
+      elements = ele;
+    }
     const { applyToParents } = this.opt;
     [].forEach.call(elements, (element) => {
       if (applyToParents) {


### PR DESCRIPTION
現状、単一のHTMLElementをそのまま引数に入れてScrollHintを初期化することはできず、一度配列に入れる必要がありましたが、このPRではそれを解消します。
また、TypeScriptの型定義では `NodeListOf<HTMLElement>` のみを受け付けるようになっていましたが、HTMLElementの配列（`HTMLElement[]`）でも実動上問題なさそうでしたので、型定義も併せて更新しました。

これにより、以下のように記述することができるようになります（Vue）：

```vue
<template>
    <div>
        <div ref="scroller"><!-- 横長な要素 --></div>
    </div>
</template>

<script setup lang="ts">
import { onMounted, useTemplateRef } from 'vue';
import ScrollHint from 'scroll-hint';

const scroller = useTemplateRef('scroller');

onMounted(() => {
    if (scroller.value == null) return;
    new ScrollHint(scroller.value, { // ←単に要素を指定するだけでも動くように
        i18n: {
            scrollable: 'スクロールできます',
        },
    });
})
</script>
```

別途ビルドしたもの（/js配下）もこのPRに含めるべきかどうかがわかりませんでしたので一旦含めておりません。